### PR TITLE
Refactor P/Invoke and RECT struct usage

### DIFF
--- a/src/AvalonDock/Controls/Shell/SystemParameters2.cs
+++ b/src/AvalonDock/Controls/Shell/SystemParameters2.cs
@@ -20,7 +20,13 @@ namespace Microsoft.Windows.Shell
     using System.Windows;
     using System.Windows.Media;
 
+    using global::Windows.Win32.Foundation;
+
     using Standard;
+
+    using Win32 = global::Windows.Win32;
+
+    using static AvalonDock.Win32Helper;
 
     public class SystemParameters2 : INotifyPropertyChanged
     {
@@ -173,16 +179,16 @@ namespace Microsoft.Windows.Shell
 
             // TITLEBARINFOEX has information relative to the screen.  We need to convert the containing rect
             // to instead be relative to the top-right corner of the window.
-            var rcAllCaptionButtons = RECT.Union(tbix.rgrect_CloseButton, tbix.rgrect_MinimizeButton);
+            var rcAllCaptionButtons = tbix.rgrect_CloseButton.Union(tbix.rgrect_MinimizeButton);
             // For all known themes, the RECT for the maximize box shouldn't add anything to the union of the minimize and close boxes.
-            Assert.AreEqual(rcAllCaptionButtons, RECT.Union(rcAllCaptionButtons, tbix.rgrect_MaximizeButton));
+            Assert.AreEqual(rcAllCaptionButtons, rcAllCaptionButtons.Union(tbix.rgrect_MaximizeButton));
 
-            var rcWindow = NativeMethods.GetWindowRect(_messageHwnd.Handle);
+            Win32.PInvoke.GetWindowRect(new HWND(_messageHwnd.Handle), out RECT rcWindow);
 
             // Reorient the Top/Right to be relative to the top right edge of the Window.
             var deviceCaptionLocation = new Rect(
-                rcAllCaptionButtons.Left - rcWindow.Width - rcWindow.Left,
-                rcAllCaptionButtons.Top - rcWindow.Top,
+                rcAllCaptionButtons.left - rcWindow.Width - rcWindow.left,
+                rcAllCaptionButtons.top - rcWindow.top,
                 rcAllCaptionButtons.Width,
                 rcAllCaptionButtons.Height);
             var logicalCaptionLocation = DpiHelper.DeviceRectToLogical(deviceCaptionLocation);

--- a/src/AvalonDock/NativeMethods.txt
+++ b/src/AvalonDock/NativeMethods.txt
@@ -23,3 +23,10 @@ SetWindowsHookExW
 UnhookWindowsHookEx
 CallNextHookEx
 SendMessage
+GetMonitorInfoW
+MonitorFromWindow
+CreateRectRgnIndirect
+SetWindowRgn
+GetWindowPlacement
+GetWindowRect
+AdjustWindowRectEx

--- a/src/AvalonDock/Win32Helper.cs
+++ b/src/AvalonDock/Win32Helper.cs
@@ -10,6 +10,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Windows;
+using System.Windows.Media.Media3D;
 
 using Windows.Win32;
 using Windows.Win32.Foundation;
@@ -72,6 +73,27 @@ namespace AvalonDock
         /// A window is about to receive the keyboard focus <seealso href="https://learn.microsoft.com/en-us/windows/win32/winmsg/cbtproc"/>.
         /// </summary>
         public const int HCBT_ACTIVATE = 5;
+
+        public static RECT Offset(this RECT rect, int dx, int dy)
+        {
+            rect.left += dx;
+            rect.top += dy;
+            rect.right += dx;
+            rect.bottom += dy;
+
+            return rect;
+        }
+
+        public static RECT Union(this RECT rect1, RECT rect2)
+        {
+            return new RECT
+            {
+                left = Math.Min(rect1.left, rect2.left),
+                top = Math.Min(rect1.top, rect2.top),
+                right = Math.Max(rect1.right, rect2.right),
+                bottom = Math.Max(rect1.bottom, rect2.bottom),
+            };
+        }
 
         public static bool GetWindowZOrder(IntPtr hwnd, out int zOrder)
         {


### PR DESCRIPTION
- Removed MONITORINFO class and RECT struct from NativeMethods.cs. 
- Removed several P/Invoke methods from NativeMethods.cs. 
- Moved RECT struct to AvalonDock namespace in Win32Helper.cs. 
- Extended RECT struct with Offset and Union methods. 
- Updated SystemParameters2 and WindowChromeWorker to use new RECT. 
- Updated Win32Helper.cs to include RECT struct and new methods. 
- Added new P/Invoke methods to NativeMethods.txt.
- Updated SystemParameters2.cs and WindowChromeWorker.cs to use new P/Invoke methods.